### PR TITLE
Update URLs for building to new GitHub location

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
             currentBuild.description = env.DESCRIPTION
         }
         container('container') {
-          git branch: "${BUILD_BRANCH}", url: 'https://git.eclipse.org/r/orbit/orbit-recipes'
+          git branch: "${BUILD_BRANCH}", url: 'https://github.com/eclipse/orbit.git'
         }
       }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -18,9 +18,9 @@
 
   <scm>
     <!-- reset SCM information so that we get a good Maven default -->
-    <connection>scm:git:git.eclipse.org:/gitroot/orbit/recipes.git</connection>
-    <developerConnection>scm:git:git.eclipse.org:/gitroot/orbit/recipes.git</developerConnection>
-    <url>http://git.eclipse.org/c/orbit/recipes.git/</url>
+    <connection>scm:git:https://github.com/eclipse/orbit.git</connection>
+    <developerConnection>scm:git:https://github.com/eclipse/orbit.git</developerConnection>
+    <url>https://github.com/eclipse/orbit/</url>
   </scm>
 
   <modules>

--- a/releng/mavenparent/pom.xml
+++ b/releng/mavenparent/pom.xml
@@ -14,9 +14,9 @@
   <description>Maven parent for Orbit recipes.</description>
 
   <scm>
-    <connection>scm:git:git.eclipse.org:/gitroot/orbit/recipes.git</connection>
-    <developerConnection>scm:git:git.eclipse.org:/gitroot/orbit/recipes.git</developerConnection>
-    <url>http://git.eclipse.org/c/orbit/recipes.git/</url>
+    <connection>scm:git:https://github.com/eclipse/orbit.git</connection>
+    <developerConnection>scm:git:https://github.com/eclipse/orbit.git</developerConnection>
+    <url>https://github.com/eclipse/orbit/</url>
   </scm>
 
   <properties>
@@ -70,7 +70,7 @@
     <forceIpFilesUpdate>false</forceIpFilesUpdate>
 
     <!-- property for generating Eclipse source reference bundle headers -->
-    <tycho.scmUrl>scm:git:https://git.eclipse.org/r/p/orbit/recipes.git</tycho.scmUrl>
+    <tycho.scmUrl>scm:git:https://github.com/eclipse/orbit.git</tycho.scmUrl>
 
     <!-- by default complain if working tree is dirty (error|warning|ignore) -->
     <dirtyWorkingTree>error</dirtyWorkingTree>

--- a/releng/repository-simrel/Jenkinsfile
+++ b/releng/repository-simrel/Jenkinsfile
@@ -66,7 +66,7 @@ spec:
     stage('Prepare') {
       steps {
         container('container') {
-          git branch: "master", url: 'https://git.eclipse.org/r/orbit/orbit-recipes'
+          git branch: "master", url: 'https://github.com/eclipse/orbit.git'
         }
       }
     }


### PR DESCRIPTION
The ip_log.xml also has the git URL in it, however touching these files means that all the bundles will get a new qualifier. Therefore, because we don't want to use ip_log.xml anymore (See Bug 581504) these URLs have not been updated.

Part of #1
