### PR TITLE
Move key content for Orbit from wiki.eclipse.org to GitHub

### DIFF
--- a/Add-bundle-in-5-minutes.md
+++ b/Add-bundle-in-5-minutes.md
@@ -1,0 +1,97 @@
+For the long version See [Adding Bundles to
+Orbit](Add-bundle.md)
+
+This is for primarily meant as a guide for contributing a bundle to make
+its way into a release. This guide assumes all the steps to get approval
+for the bundle itself have already been performed.
+
+See [readme](README.md) and [Adding a bundle](Add-bundle.md) for a more thorough explanation
+
+## Setup
+
+-   Fork and Clone this repository
+
+## Creation/Preparation
+
+-   Choose a folder under which to create the recipe and then create it
+    there using the below mvn command or the *create-\*-recipes.sh* if
+    any:
+
+`$ cd github/mongodb`  
+`$ mvn ebr:create-recipe -DgroupId=org.mongodb -DartifactId=mongo-java-driver -Dversion=3.4.1 -DbundleSymbolicName=org.mongodb.mongo-java-driver`
+
+-   Modify recipe pom and osgi.bnd to suite the needs of the bundle. If
+    the bundles has dependencies, make sure to specify them under the
+    Import-Package header in the osgi.bnd as opposed to just leaving it
+    as '\*;resolution:=optional'.
+
+`$ cd org.mongodb.mongo-java-driver_3.4.1`  
+`$ $EDITOR pom.xml`  
+`$ $EDITOR osgi.bnd`
+
+-   Perform a test build of the package.
+
+`$ mvn -U clean package -DdirtyWorkingTree=warning`
+
+## Add To Build
+
+-   Add the new recipe to the category pom as a module
+
+(eg. <module>`org.mongodb.mongo-java-driver_3.4.1`</module>)
+
+`$ cd ../`  
+`$ $EDITOR pom.xml`
+
+-   Add the recipe bundle to the aggregation feature to ensure it ends
+    up in the generated repository
+
+`$ cd ../../`  
+`$ EDITOR releng/aggregationfeature/feature.xml`
+
+(eg.
+<plugin id="org.mongodb.mongo-java-driver" version="3.4.1.qualifier"/>)
+
+-   Add and commit the new recipe and changes to the aggregation
+    feature.
+
+`$ git add github/mongodb/org.mongodb.mongo-java-driver_3.4.1 releng/aggregationfeature/feature.xml`  
+`$ git commit`
+
+## Building Locally (Recommended)
+
+-   We should also test that our new recipe builds successfully prior to
+    submitting for review
+
+First we test that our recipe builds alongside all other recipes and
+install them locally to be discovered later by our aggregation feature
+
+`$ mvn clean install`
+
+Next we test that the aggregation feature builds successfully
+
+`$ mvn clean install -f releng/aggregationfeature/pom.xml`
+
+Finally, we test that the generated repository containing all bundle
+recipes builds successfully
+
+`$ mvn clean package -f releng/repository/pom.xml`
+
+## Contributing
+
+-   Lastly, we push to review by creating a Pull Request.
+
+## Consumption
+
+Once a change has been reviewed and approved, a build should be
+triggered within about an hour at
+<https://ci.eclipse.org/orbit/job/orbit-recipes/> . Once the build
+succeeds, information about where to find the build page, as well as the
+generated p2 repository can be found at the bottom of the build's logs.
+
+The automated builds are analogous to nightly builds, in that they are
+not usually retained for long and are generally used merely for testing
+purposes. For more stable repositories, committers have the ability to
+push integration, milestone, and recommended (I, S, R) builds that can
+also be promoted to the [downloads
+page](http://download.eclipse.org/tools/orbit/downloads/) for
+visibility.

--- a/Add-bundle.md
+++ b/Add-bundle.md
@@ -1,0 +1,535 @@
+## Before You Do Anything
+
+### Project Approvals and the IP Process
+
+Don't waste your time working up an OSGi bundling of a third-party
+library before you know that you will be able to use it. So, first start
+the legal approval process with the Eclipse Foundation's legal
+department.
+
+See the IP Provenance item on [the bundle
+checklist](Bundle-checklist.md#ip-provenance).
+You can make a quick draft of the new bundle. Send and email to
+[orbit-dev](https://accounts.eclipse.org/mailing-list/orbit-dev) for
+advice.
+
+## Checklist
+
+The [Orbit Bundle Checklist](Bundle-checklist.md) provides
+a concise checklist of the following steps.
+
+## Setting up GIT for the new bundle
+
+### Creating a new project for an Orbit bundle
+
+When adding an entirely new library to Orbit, you have to create a
+module in GIT to house the content. Follow these steps to set this up
+the first time.
+
+1.  First decide on the desired name (see [Bundle
+    Naming](Bundle-naming.md)) and make sure to know the
+    groupId, artifactId, and version for the maven artifact that will
+    serve as a base for the bundle. For this example we'll use
+    com.example.foo.
+2.  Make sure you have this repo cloned
+1.  You need to install the eclipse ebr maven plugin in your machine
+    (see [1](https://github.com/eclipse/ebr))
+2.  Choose a folder in orbit-recipes git repository under which to
+    create the recipe and then create it there using (you might need to
+    use the complete ebr name as discussed in the ebr README)
+
+`$ mvn ebr:create-recipe -DgroupId=com.example -DartifactId=foo -Dversion=1.0.0 -DbundleSymbolicName=com.example.foo`
+
+1.  If you are starting a new recipe, you need to add a parent pom to
+    the new recipe folder and a module (or modules) with its respective
+    pom for the recipes that will be group under the new recipe. Use the
+    existing recipes as guidance.
+
+## Library not available on Maven Central
+
+The orbit build process, which makes use of CBI automates a large amount
+of the work required to create a bundle from a regular jar library.
+However, it depends heavily on the library being available from a maven
+repository. The advantage to this approach is it takes away the burden
+of uploading the library onto the committers while also opening up the
+possibility of having contributors propose changes. Many libraries meet
+this requirement and can be found on Maven Central, but for those that
+are not there, or cannot be deployed there is an alternative.
+
+The Orbit project provides a more convenient way to upload the library
+as well as its sources to our own (Nexus) maven repository where
+approved artifacts can be hosted. This is provided through a JIPP
+(Jenkins Instance Per-Project) at
+<https://ci.eclipse.org/orbit/job/upload-approved-artifacts/> .
+Committers would merely trigger a build by providing the library, its
+sources, the GAV (groupId, artifactId, version) that will identify it,
+and the build would deploy the artifact(s).
+
+## Adding a library for the first time
+
+The page titled, [Adding Bundles To Orbit In 5
+Minutes](Add-bundle-in-5-minutes.md) contains all
+the necessary information for adding a library to Orbit for the first
+time. The process is most straightforward when the library exists on
+Maven Central repository.
+
+## Moving an existing bundle to Orbit
+
+Adding an existing bundle to Orbit is currently no too different from
+adding a library for the first time (See [Adding Bundles To Orbit In 5
+Minutes](Add-bundle-in-5-minutes.md)). The main
+difference is that with an existing bundle, certain OSGi metadata may
+need to be preserved while others may need to be reproduced to be as
+identical to the original metadata.
+
+## Project setup
+
+No matter how you created your bundle in Orbit, the following outlines
+how the project itself should be configured. Remember, it is often
+simpler to use the Resource Navigator rather than the Project Explorer
+since you really need to see all the files in your project and you
+aren't really compiling or building anything.
+
+-   In the MANIFEST.MF, ensure that the **Bundle-Classpath:** header is
+    either missing or has only '.' as a value.
+-   For most cases there is no need to have **Eclipse-Autostart: true**
+    or such headers since this library is generic and will not have an
+    OSGi bundle activator.
+-   Similarly, for most bundles there is no need to set the
+    **singleton:=true** on the **Bundle-SymbolicName** header.
+-   Of course, you should set the
+    **Bundle-RequiredExecutionEnvironment** header to the absolute
+    minimum JRE required by the library. That can often be difficult to
+    figure out. Look for some tools in PDE to help with this...
+-   Where possible use **Import-Package** instead of **Require-Bundle**.
+    This reduces sensitivity to different bundlings of the same library.
+-   The Orbit community has agreed that **Bundle-Version** numbers
+    should be the original library version number followed by .qualifier
+    in the fourth segment. In the event that the original number is
+    already four segments, that version number should be used and then
+    followed by "\_qualifier". *Note that this versioning scheme differs
+    from the normal Eclipse plug-in [Version
+    Numbering](https://wiki.eclipse.org/Version_Numbering) if the external library
+    does not follow the Eclipse rules.*
+-   It is suggested that a 3 part version number be included in the
+    project name, in the *.project* file. This is to enable those that
+    use the Eclipse IDE preference to "Use .project project name instead
+    of module name on check out". This makes it easier to check out
+    multiple versions of a bundle (project) from its various branches.
+    For example,
+
+<projectDescription>  
+`  `<name>`javax.xml_1.3.4`</name>  
+`  `<comment></comment>  
+`  `<projects>  
+`  ...`  
+`  ...`  
+`  `</projects>  
+</projectDescription>
+
+## The osgi.bnd file
+
+The osgi.bnd file is used to generate the MANIFEST.MF file for the
+bundle so it is very important the contents of this file are correct.
+This can be done by building the bundle locally to ensure the final
+manifest generated is correct. This file also has a set of predefined
+instructions (See
+<http://bnd.bndtools.org/chapters/825-instructions-ref.html>). The
+following is a list of items to consider when finalizing the osgi.bnd
+file.
+
+### Import-Package should have an optional catch-all
+
+All Import-package statements within the osgi.bnd file should end in a
+'\*;resolution:=optional' statement that serves as a fallback in the
+event that any packages are missed.
+
+`Import-Package: \`  
+` org.foo.a.*;version="${range;[===,=+);${package-version}}", \`  
+` org.bar.b.*;version="${range;[===,=+);${package-version}}", \`  
+` *;resolution:=optional`
+
+It has been argued that things could be made easier by simply having
+'Import-Package: \*' and have all dependencies be automated. However,
+contributors should be aware of every dependency that their package
+uses, so stating them explicitly should be required. This approach still
+allows grouping of various packages under a similar namespace using
+wild-card matches.
+
+### Emit No Import-Package
+
+This can be done very simply by defining :
+
+`Import-Package: !*`
+
+### Permit Require-Bundle
+
+By default, the Require-Bundle header is removed from the final
+generated manifest by the ebr-maven-plugin, and usage of this header in
+Orbit manifests is discouraged. If there is a good reason for why it
+needs to be used one can permit its use by overriding the property in
+the bundle's corresponding pom.xml file :
+
+<properties>  
+`  `  
+`  <recipe.removeadditionalheaders></recipe.removeadditionalheaders>`  
+</properties>
+
+Now, the 'Require-Bundle' header may be defined in the osgi.bnd file.
+
+### Bypass Errors
+
+In some cases the ebr-maven-plugin may halt execution due to what it may
+perceive as a packaging error. If the issue is in fact a false positive,
+one can bypass it in the osgi.bnd file of the module causing the issue
+using the fixupmessages instruction. See
+<http://bnd.bndtools.org/instructions/fixupmessages.html> for more
+information :
+
+`-fixupmessages "Classes found in the wrong directory"; is:=warning`
+
+The above instruction would ensure that any error/warning message
+"Classes found in the wrong directory", would be set as a warning.
+
+### <s> build.properties entries and .classpath file </s>
+
+This is not necessary as the process of creating the bundles is handled
+automatically.
+
+A special note about the `build.properties` file:
+
+For your binary bundle (not your source bundle), in most cases it will
+have an entry like:
+
+    output..=.
+
+This tells PDE that when someone has the project loaded into their
+workspace and other projects depend on it, then PDE should look at the
+project root for class files to compile against.
+
+Note that it is important **not** to have a `source..=.` entry in your
+build.properties file as that will cause the bundle to be compiled and
+this can be a problem with the nested source bundles.
+
+A special note about the `.classpath` file:
+
+Be sure the class folders are listed in the project's `build path`
+properties and that they are marked *exported*. This only effects the
+.classpath file and effects how PDE and JDT "find" the classes if it
+happens to be checked out in a persons workspace while they are coding
+other plugins.
+
+### Special Detailed Notes on the four segment case
+
+As documented above, in the event that the original package number is
+already four segments, that version number should be used and then
+followed by "\_qualifier". These leads to a few differences in exactly
+how the final qualifier is computed and referred to in features and map
+files. The following example are taken from [bug
+152588](https://bugs.eclipse.org/bugs/show_bug.cgi?id=152588).
+
+For example, for the junit version 4.1.0.01, the manifest.mf file
+specifies
+
+`   Bundle-Version: 4.1.0.01_qualifier`
+
+But, the feature.xml file specifies
+
+`   `<plugin id="org.junit" version="4.1.0.qualifier" />
+
+The resulting jar file is named as follows.
+
+`    org.junit_4.1.0.01_200704231307.jar`
+
+And, the resulting bundle version matches the file name, for example,
+
+`    Bundle-Version: 4.1.0.01_200704231307`
+
+#### Avoid qualifiers that change with date and time of each build
+
+Note: to avoid the "current date and time" substitution for qualifier
+version -- which would cause a version increment each build, even though
+contents not changed, use the exact same form in the feature.xml file.
+(See .) For example, use 10.5.1.1_qualifier in the feature.xml file,
+such as,
+
+`  `<plugin id="org.apache.derby" version="10.5.1.1_qualifier" />
+
+This will then cause the last time of modification to be substituted for
+'qualifier', resulting in versions such as 10.5.1.1_v201108232300. This
+may look different from usual, but will remain constant from build to
+build.
+
+### Special Detailed Notes on the RC case
+
+Sometimes bundles need to be added that aren't full releases, but
+'release candidates.' These release candidate plug-ins should share the
+same branch as their full release cousins.
+
+For example, let's say we have a plug-in ch.ethz.iks.slp 1.0.0 RC2, the
+manifest.mf file specifies
+
+`   Bundle-Version: 1.0.0.RC2_qualifier`
+
+The branch the plug-in would be created in is v1_0\_0 even though it's
+an RC2 release. Once 1.0.0 came out or say RC3, the branch would be
+updated with the info code. This essentially limits us to one "1.0.0"
+release at a time, but it's an acceptable workaround for the time being.
+
+The feature.xml file specifies
+
+`   `<plugin
+        id="ch.ethz.iks.slp"
+        download-size="0"
+        install-size="0"
+        version="1.0.0.qualifier" />
+
+And, the (multiversion) map file specifies
+
+`    plugin@ch.ethz.iks.slp,1.0.0=v200701261101,:pserver:anonymous....`
+
+The resulting zip file is named as follows (zip, in this case, since it
+is not a jarred bundle).
+
+`    ch.ethz.iks.slp_1.0.0.RC2_200704231307.zip`
+
+And, the resulting bundle version matches the file name, for example,
+
+`    Bundle-Version: 1.0.0.RC2_200704231307`
+
+Note: It's incredibly important that the final release is
+lexicographically greater than the release candidate so it can be
+updated properly. For example, ch.ethz.iks.slp_1.0.0.RC2_v200801291200
+is \> than ch.ethz.iks.slp.1.0.0_v200801291200 because "R" is considered
+greater than "v"
+
+## Bundle Packaging Options
+
+### Embedded Jars
+
+Certain bundles may require that class files be provided as embedded
+jars, and referenced under the `Bundle-ClassPath` attribute of the
+`MANIFEST.MF`, as opposed to exploded jars at the root of the class
+path.
+
+To achieve this, simply define the property
+`<recipe.unpackdependencies>false</recipe.unpackdependencies>` in the
+bundle's module. One can further customize the naming of the embedded
+jars using `<recipe.stripversion>true</recipe.stripversion>` to further
+strip out the versioning from the listed jars.
+
+<properties>  
+`  <recipe.unpackdependencies>false</recipe.unpackdependencies>`  
+`  <recipe.stripversion>true</recipe.stripversion>`  
+</properties>
+
+### Excluding Source Bundles
+
+In cases where certain bundles must be distributed 'binary only',
+without corresponding source bundles, this can be achieved through the
+<excludes> configuration option of the `tycho-source-feature-plugin` in
+`releng/mavenparent/pom.xml`
+
+## Adding Bundles To A Maintenance Release
+
+In some cases, it may be required to add bundles to maintenance releases
+(eg. Oxygen.2) while active development is taking towards a newer
+release (eg. Photon). This is simply a matter of cherry picking (through
+git) the necessary changes onto the corresponding maintenance branch.
+
+1.  Locate the maintenance branch corresponding to the release. It
+    should be named RX_Y , where X.Y would be the version of the Eclipse
+    release.
+2.  `git cherry-pick ${COMMIT}` (resolving any conflicts)
+3.  `GIT_COMMITTER_DATE="$(git show -s --format=%cd)" git commit --amend`
+
+The `GIT_COMMITTER_DATE` environment variable ensures that the commit
+date used for the cherry-picked commit matches that of the original
+commit on the development branch. This is necessary to ensure that the
+bundle built using the maintenance branch will be given the same
+qualifier (through tycho-packaging-plugin's jgit time stamp provider) as
+the original bundle in the event that there are no additional changes.
+
+## Packaging licensing information
+
+When packaging a third party library we have to ensure that the
+licensing information is present and correctly used. Generally, the
+**about_files**, **about.html**, **build.properties**, and the
+**ip_log.xml** files will be automatically generated and correctly
+defined. They should still be checked to ensure the correct license has
+been detected and in the case of the **ip_log.xml** file, some
+additional fields will need to be filled in manually such as the
+corresponding ATO (Add To Orbit) CQ.
+
+## National Language Considerations
+
+The following are some tips to help make sure any text in the bundle is
+not "garbled" during network or storage transfers and it is capable of
+being properly translated to languages other than English.
+
+-   As I think is true for all projects in an Eclipse repository, it is
+    recommend you set the project's default encoding preference to
+    ISO-8859-1. This project encoding applies to files that do not
+    otherwise have any ability to specify their encoding (such as ".txt"
+    or ".java" files). This is a good "single byte" encoding in general,
+    and I think the CVS Repository Server assumes ISO-8859-1 as the
+    default. Having it set as a project setting is good, so that, for
+    example, if someone on windows checks it out and makes changes, and
+    someone on Linux checks it out and makes changes, the default
+    encoding for that project will be the same, no matter what the
+    default encoding are on those different OS platforms.
+
+<!-- -->
+
+-   Be sure to "externalize" all the string in your manifest.mf files,
+    and plugin.xml files, if you have any. There is usually at least
+    two: the provider's name and the bundle's name.
+
+## <s> What to use as Provider Name? </s>
+
+This is automatically generated by the orbit-recipes build but if for
+some reason this isn't being generated, Use "Eclipse Orbit".
+
+This is for the `Bundle-Vendor:` header in manifest.mf files. This
+should be externalized so what's in the manifest.mf file is a key,
+usually something like
+
+`Bundle-Vendor: %Bundle-Vendor.0`
+
+and then in the plugin.properties, or bundle.properties file is there
+you would have
+
+`Bundle-Vendor.0 = Eclipse Orbit`
+
+Historically, it used to be required to use "Eclipse.org". Beginning in
+Galileo, however, the recommendation (requirement, actually) is to use
+'Eclipse' followed by the project name, avoiding acronyms and
+abbreviations etc, acknowledging that these are for end-users to read.
+The appropriate "project name" differs from one top level project to
+another. For example, in WTP, all sub-projects use the top level project
+name ("Eclipse Web Tools Platform"). But in Tools, since the
+sub-projects are all fairly different from one another, the Tools PMC
+decided to use "Eclipse" followed by sub-project name. So, that's
+"Eclipse Orbit" for us.
+
+There is one exception. We have some bundles that are pre-built and we
+just store them in our repository. There, the provider name is left as
+it is, of course, since it is pre-built. But anything we build/assemble
+should be "Eclipse Orbit".
+
+## Avoid packing (pack200) nested jars
+
+Unless there is an important reason to, avoid "packing" jars nested
+inside Orbit bundles. The reason is that changes in Java 7 make these
+packed children impossible to extract so tools such as p2 then has to
+"fall back" and use the plain jar version of the bundle anyway ... all
+adding up to a slight performance impact. See for more details.
+
+Mechanically, the way to accomplish this is to include a file named
+'eclipse.inf' in the META-INF folder that has contents of
+
+`jarprocessor.exclude.children.pack=true`
+
+Or, if you want to excluded nested jars from packing and from signing,
+you can use
+
+`jarprocessor.exclude.children=true`
+
+Whether or not to exclude children from signing depends on how the jar
+is anticipated to be used. In some cases, consumers might expect it to
+be signed, in other cases, they might expect it not to be signed. For
+use in the Eclipse IDE, it does not particularly matter, the default
+Equinox settings will not 'verify' nested jars, though there are some
+server runtimes that do. Most bundles in Orbit use
+`jarprocessor.exclude.children=true`.
+
+Occasionally, source-bundles also have "nested jars", so those would
+also need the eclipse.inf file put in their META-INF directory.
+
+## Remember to retain important aspect of original jar manifest
+
+Part of the goal of creating Orbit bundles, is that when ever possible,
+the Orbit bundle can continue to be used as a jar, just as it would have
+been originally.
+
+In some cases, this means there may be aspects in the original jar's
+manifest that should be carried over to the manifest in the bundle.
+
+### Examples of things important to retain
+
+One example, if the original jar's manifest contains a *Main-Class*
+directive, then the bundle's manifest should contain the same
+*Main-Class* directives. One case of this is the Rhino bundle
+(org.mozilla.javascript). It originally contained
+
+` Main-Class: org.mozilla.javascript.tools.shell.Main`
+
+which prints the version and starts up an interpreter "shell". It's best
+to maintain that sort of functionality whenever possible.
+
+### Examples of things not to retain
+
+An example of what not to retain was raised in . Some jars have
+*Class-Path:* directives in their MANIFEST.MF files. This is the
+"non-OSGi" way of expressing a dependency on another jar (not to be
+confused with OSGi's *Bundle-ClassPath:* which is a different concept).
+In the cases I've seen, these 'Class-Path' directives become meaningless
+in OSGi bundles, either because the path or the jar referenced in that
+'Class-Path' no longer exists, or it exists in a different form, such as
+with with version information added to the name. In some cases it
+becomes part of what a bundle "requires", which, naturally, is expressed
+in the "OSGi way". Having the 'Class-Path' there has no effect on the
+bundle when run with OSGi and none of our build systems pay attention to
+it, but as mentioned in there are some build systems that will flag any
+"non-existing file" or "invalid path" as an error, interfering with the
+build. Hence, it's a good idea to remove any lines that have a
+'Class-Path' directive. In most cases, though, this directive is
+probably useful in helping you "convert" the information when you create
+the OSGi bundle, that is, that you can add a proper *Require-Bundle:* to
+express the same relationship in the OSGi way.
+
+## Export-Package guidelines
+
+Normally, all packages in a bundle should be listed in the
+Export-Package declaration in MANIFEST.MF.
+
+But, if a bundle has packages that are not normally part of its
+namespace, those should not be blindly exported, unless it is known that
+they are supposed to be. That is, the first assumption should be the
+bundle simply uses those packages internally, and are not part of its
+API to expose to the rest of the world. See for a case where exporting
+"foreign" packages can cause problems.
+
+Also, normally, all exported packages should list the version they are
+exporting. Keep in mind that if a package in an interface, defined by a
+specification, then the version of the exported package should be the
+version of the specification, not the bundle it is in. For example, we
+use `"Export-Package: javax.xml;version="1.3"`, even though the package
+is in the javax.xml bundle versioned at 1.3.4.
+
+## Adding your bundle to the feature.xml
+
+There is a feature in Orbit that is used solely to drive the build. To
+modify it, checkout this repo. It will be located under releng/aggregationfeature/feature.xml.
+You'd add your bundle to this feature like any other. For example,
+
+`   `<plugin id="javax.servlet" version="2.3.0.qualifier" />
+
+
+## Adding your bundle to the Orbit Build
+
+See [ Adding To
+Build](Add-bundle-in-5-minutes.md).
+
+## Final steps (a.k.a being a good OSS citizen)
+
+It's a good practice to contribute back OSGi packaging - many upstream
+are not aware of OSGi and will appreciate patches. Having OSGi manifests
+upstream has a couple of advantages:
+
+-   shared burden of maintenance
+-   easier adoption (3rd party software can use newer versions before it
+    is located in Orbit and drive Eclipse migration to
+    latest-and-greatest versions).
+-   spreading the word about OSGi
+

--- a/Bundle-checklist.md
+++ b/Bundle-checklist.md
@@ -1,0 +1,63 @@
+Here are the steps for adding a new bundle to Orbit. Please use them as
+a checklist to ensure that you have done everything correctly when you
+have a new bundle to add.
+
+### IP Provenance
+
+All contributions to Orbit need to be approved for use, either
+automatically or by raising an iplab issue for the content if the
+automatic check does not work. The automatic check is done by activating
+the "license-check" profile, e.g. `mvn verify -P license-check`. If the
+automatic check fails you may need to raise an [iplab issue (choose
+vet-third-party in Description dropdown to get correct
+template)](https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/new).
+Send and email to
+[orbit-dev](https://accounts.eclipse.org/mailing-list/orbit-dev) for
+advice.
+
+### Add the Bundle to Git
+
+In Orbit we store the metadata necessary to generate a bundle in the
+[orbit-recipes](http://git.eclipse.org/c/gerrit/orbit/orbit-recipes.git/)
+Git repository. Look at our [Adding Bundles to
+Orbit](Add-bundle.md) document for instructions on
+how to initially put your bundle into Orbit.
+
+### Verify the osgi.bnd
+
+The osgi.bnd file is used to generate the bundle manifest
+(`META-INF/MANIFEST.MF`), and while this file gets generated with some
+defaults, it is very important to verify it as well as the contents of
+the generated manifest to ensure the final result is what one expects.
+In particular the `Import-Package` header patterns should be verified.
+
+### Update the Feature
+
+In Eclipse we build features so when we add a new bundle to Orbit, we
+must add it to the feature so the builder is aware that we should build
+it. Please update `releng/aggregationfeature/feature.xml` in
+[orbit-recipes](https://git.eclipse.org/c/orbit/orbit-recipes.git/) with
+an entry for your new bundle. (you don't need one for the source bundle)
+Changes to the Orbit feature are done in the master branch on Git.
+
+<plugin id="javax.servlet" version="2.3.0.qualifier" />
+
+### Final Notes
+
+-   When in doubt, look at the other bundles in Orbit to see what they
+    did.
+-   Always check the build output to ensure that it is what you expect.
+
+### Example Layout
+
+Here is an example structure for a bundle.
+
+    my.bundle.id_1.0.0/
+        pom.xml
+        src/
+            main/resources/
+                about_files/LICENSE.txt
+                about.html
+        .project
+        osgi.bnd
+

--- a/Bundle-naming.md
+++ b/Bundle-naming.md
@@ -1,0 +1,131 @@
+Bundling third party code libraries such as Log4j or Commons Logging is
+generally easy. Choosing a bundle symbolic name (BSN) for the bundle can
+be challenging. There are a number of questions that must be asked,
+options investigated and decisions made. The information here is an
+attempt to capture some of these issues in an effort to get some level
+of uniformity within the Eclipse and OSGi communities. This information
+is put here to generate discussion and surface and resolve issues.
+
+## Issue 1 : Namespace ownership
+
+While it is suggested that BSN's be in the form of reverse domain names,
+this is not required by the OSGi spec. Assuming you want to follow that
+guideline, there are two choices for the BSN; use your namespace or use
+the namespace of the library's originator. Some thoughts from the
+community...
+
+-   Using your namespace correctly stamps the bundle as your view of the
+    library
+-   Using the originator's namespace correctly attributes
+    credit/ownership for the function
+-   Using the originator's namespace inhibits the originator from free
+    use of their namespace
+-   Using your namespace leads to many names for the same thing (e.g.,
+    org.eclipse.orbit.jetty and org.apache.felix.jetty vs. just
+    org.mortbay.jetty)
+
+As you can see, there are reasonable yet diametrically opposed views.
+There is some clarity in this space however.
+
+-   if you modify or add to the library code then using your own
+    namespace is probably best as you are not incorrectly assigning
+    responsibility (i.e., blame) to the originator.
+
+## Issue 2 : Evolution
+
+On the whole the issues raised here only come up because library
+producers are not producing OSGi bundles. The hope is that over time
+library producers will change and begin to ship OSGi bundles natively.
+As such, they will take responsibility for choosing a BSN. Some thoughts
+from the community...
+
+-   When that happens, what if they choose the same name as we choose
+    now?
+-   The choice we make now will help guide the producers when picking a
+    BSN (we are setting the example)
+-   What about version number clashes?
+-   What about people who are using Require-Bundle?
+
+## Option 1 : Dominant package name
+
+For many libraries it is easy to identify one Java package as being "the
+root" of the function. This is a reasonable choice for the BSN assuming
+you are comfortable using the originator's domain name. This option
+implies names such as org.mortbay.jetty.
+
+Note that some libraries do not use full domain names in their package
+naming. MX4J packages for example are simply mx4j.\*. Following this
+option would lead to a BSN of just mx4j. As noted above, this is
+perfectly legal. One could opt here to add in the remaining domain
+segments and go for net.sourceforge.mx4j.
+
+## Option 2 : Your namespace + originator simple name
+
+If you would prefer to use your own namespace (or have modified/added
+code) a BSN of the form org.eclipse.orbit.jetty seems reasonable. Here
+the first part is the shortest sequence that is in your control and the
+remaining part is the "short name" of the originator's function.
+
+## Option 3 : Your namespace + originator's full name
+
+To be 100% safe with respect to namespace clashes, you could use the
+originator's full name in conjunction with your namespace to create a
+BSN of the form org.eclipse.orbit.org.mortbay.jetty. Here the first part
+is the shortest sequence that is in your control and the remaining part
+is the "full name" of the originator's function.
+
+Jeff McAffer says: this seems excessive.
+
+## Issue 3 : Distinguishing different implementations
+
+In some cases, there are different implementations of a package or
+interface, even of the exact same version. In this case, the simple
+package name and version is not enough to distinguish the different
+implementations. Note that in Eclipse, it is generally assumed that a
+bundle symbolic name and version specify a unique set of executable
+bits, so it would be confusing to distribute bundles with same name,
+same version, but different implementations. (See bug
+[226813](https://bugs.eclipse.org/bugs/show_bug.cgi?id=226813) for some
+discussion of this).
+
+javax.mail has been one of the bundles that has several implementors
+(sun, glassfish, geronimo, etc) so looking at the latest versions of
+those bundles in Orbit would help illustrate some of these issues and
+problems.
+
+There are two things that should be done when there are different
+implementations of the same API from different vendors.
+
+First, 'vendor' attribute should be used when exporting packages, so
+that clients who care, can specify it on their import package
+statements. For example, from the javax.mail from glassfish, in the
+manifest.mf file one export line looks like
+
+` javax.mail; vendor=glassfish; version="1.4.1",`
+
+For contrast, this could be
+
+` javax.mail; vendor=geronimo; version="1.4.1",`
+
+The second thing to do is to add the 'vendor' name to the end of the
+main package name (the main package name being that described in "Option
+1" above). So, for javax.mail, this would be javax.mail.glassfish or
+javax.mail.geronimo. This pattern of the putting the vendor name last is
+a little bit arbitrary, but seems to make the most sense in the big
+picture of all bundles, by putting the most significant part of the name
+first. Here, "most significant" means how someone might be looking for a
+function in an alphabetized list of bundles. So, to be explicit, it's
+assumed they are looking for "javax.mail" and then would pick which
+implementation they wanted.
+
+Note: as of this writing, some of the bundles in Orbit, do not perfectly
+match the advise given here, simply because they were done before this
+policy was decided.
+
+Also note: It is assumed we would start to use the vendor name in the
+bundle symbolic identifier only once there was an actual "conflict" in
+Orbit. Even if we know there is more than one implementation out in the
+world, there is no need to use it initially, if there is only one
+implementation in Orbit. There is no harm in doing so ... we are just
+stating it is not **required**.
+

--- a/Policies.md
+++ b/Policies.md
@@ -1,0 +1,226 @@
+Orbit itself does not have releases, per se, since the 3rd party jars
+that are bundled have already been released. But, we will still use the
+Eclipse [Simultaneous Release](https://wiki.eclipse.org/Simultaneous_Release) rhythm
+to set deadlines for ourselves and promote and retain bundles.
+
+An Orbit milestone date will be considered the same as the base Eclipse
+platform milestone date, since for anyone in a [Simultaneous
+Release](https://wiki.eclipse.org/Simultaneous_Release) to use an Orbit Bundle, it
+would have to be ready (and final) at least a week or two before their
+milestone deadline.
+
+### Continuous Builds
+
+Our continuous builds produce builds on the [downloads
+page](http://download.eclipse.org/tools/orbit/downloads). Their purpose
+is for the committers to have something to see or download and confirm
+all is as they expect it to be. These builds are often short lived and
+can be deleted without notice.
+
+Note that all new changes eventually trigger an integration (I) build
+that gets automatically promoted to the downloads page.
+
+### Milestone and Recommended Release Process
+
+Some of the steps are a little different for Recommended than
+Milestones - see comments as you go through the list.
+
+1.  Log in with your committer account on
+    <https://ci.eclipse.org/orbit/>
+2.  Go to the
+    [orbit-recipes](https://ci.eclipse.org/orbit/job/orbit-recipes/)
+    JIPP
+    1.  Click 'Build with Parameters'
+        1.  For S-builds:
+            1.  Change the `BUILD_LABEL` to `S` using the drop-down box,
+                to indicate a stable build
+        2.  For R-builds:
+            1.  Change the `BUILD_LABEL` to `R` using the drop-down box,
+                to indicate a recommended build
+    2.  Make sure `SIMREL_NAME` is set to the name of the simultaneous
+        release (eg. 2019-03) to which this build will contribute
+    3.  Make sure `DESCRIPTION` is set to the description desired on the
+        downloads page (at least e.g. 2022-06 M1, can include additional
+        notes and URLs. Cannot include double-quotes, e.g.
+        <a href='https://download.eclipse.org/tools/orbit/downloads/2022-03'>`2022-03`</a>)
+    4.  Leave everything else as-is, and click build
+    5.  Once the build succeeds, click the 'Keep this build forever'
+        button
+3.  **The notes.php** step has been removed as that is done as part of
+    the build, using `DESCRIPTION`
+4.  **The promote-to-downloads** step has been removed as that is done
+    always as part of the build now.
+5.  Announce the release of the milestone build on the orbit-dev mailing
+    list.
+    1.  Use a previous announcement email as a starting point
+    2.  To generate the p2 diffs: `p2ql diff ${oldRepo} ${newRepo}`
+        1.  To setup p2 diffs:
+            1.  `mkdir -p ~/git`
+            2.  `cd ~/git`
+            3.  `git clone `[`https://github.com/rgrunber/fedoraproject-p2`](https://github.com/rgrunber/fedoraproject-p2)
+            4.  `cd ~/git/fedoraproject-p2`
+            5.  `mvn clean package`
+            6.  `git clone `[`https://github.com/rgrunber/utils-for-eclipse`](https://github.com/rgrunber/utils-for-eclipse)
+            7.  `cd ~/git/utils-for-eclipse`
+            8.  `mvn clean package`
+            9.  Add a recent eclipse to the `PATH` (maybe best to match
+                the one listed in
+                <https://github.com/rgrunber/fedoraproject-p2/blob/5a3081a0b45599223c6dced8631bc40b218ed172/pom.xml#L61-L68>)
+            10. `./p2ql diff ${oldRepo} ${newRepo}`
+6.  Once you have made the announcement, the build is considered
+    released. Be sure to update the `referenceRepoBuild` in
+    `releng/mavenparent/pom.xml` property to reference the released
+    build. This will ensure that new packages introduced in this (just
+    announced) release have their timestamps frozen until further
+    possible changes are introduced.
+7.  Notify Eclipse Plaform by commenting in the bug with title "Eclipse
+    4.xx prerequisitres: Orbit" (see this
+    [example](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/172)
+    for the 4.24 release)
+
+### Milestones and Recommended ("Final") Bundles Area
+
+Once per milestone, (roughly simultaneous with the platform's
+milestone), a rebuild will occur on the latest commit, and the earlier
+weekly builds may be deleted. Each Milestone Build will be retained
+until an Eclipse Simultaneous Release and then all deleted.
+
+It was decided in June 12, 2007 status meeting to (still) have dated
+directories for the "final" builds, and was decided to call them
+"R-builds", which may sound like "Released", but is "Recommended" for
+Orbit, since Orbit does not have Releases in the Eclipse sense of that
+word.
+
+The bundles in "Recommended" builds will only be changed (re-created) if
+there are serious bugs found with them. Even then, any "Recommended"
+builds will be retained long term, such as for 2 years or so, so build
+scripts will not break and be re-creatable.
+
+#### Milestones and Recommended Build "Notes" Column
+
+On the main download page is a column labeled "Notes". While technically
+any "note" can be put in there, at a minimum for every "R-build" and
+"S-build" a note should be added for which Simultaneous Release the
+build was first recommended for.
+
+Adding notes to the file is a matter of "hand editing" the "notes.php"
+file on the download server. It is under
+
+`.../tools/orbit/downloads/`
+
+and new entries are added, by adding new array entries, which are
+indexed by the "display name" of the download. For example, if existing
+file started with the following:
+
+`<?php`  
+  
+`$notes = array();`  
+  
+`$notes["R20140525021250"]="Luna, Luna SR1";`  
+`$notes["R20140114142710"]="Kepler SR2";`  
+
+then the next R-build was for Mars, and named R201506011000, and no new
+R-build for Luna SR2, that file would end up starting with:
+
+`<?php`  
+  
+`$notes = array();`  
+  
+`$notes["R20150601100000"]="Mars";`  
+`$notes["R20140525021250"]="Luna, Luna SR1, Luna SR2";`  
+`$notes["R20140114142710"]="Kepler SR2";`
+
+This file, and others are stored in module
+org.eclipse.orbit.releng.downloadsites but there is no automatic update
+or anything from those files, to download server.
+
+### Milestone dates
+
+The Orbit milestones dates will be a -3 delivery (Tuesday) in
+Simultaneous Releases, to allow all projects to pick up prereqs (even
+the Platform, the 0 delivery).
+
+### Build Retention
+
+Milestone builds will be retained until the Recommend build is produced.
+
+Recommended builds will be kept forever, the most recent one(s) on
+'download.eclipse.org' but older ones will be moved to
+'archive.eclipse.org' (which is not mirrored) The old, archived builds
+should rarely be needed, used only be used if someone needed to
+re-create some old build which was based upon it, such as for long term
+maintenance.
+
+### Bundle Retention in active builds
+
+It is our Orbit project's policy that once a bundle is delivered in an
+R-build, it will be retained forever in that R-build (or its
+repository). But, in active (or, current) builds, to be used for future
+releases, we may remove old versions of bundles according to the
+following guidelines.
+
+-   Normally only 1 version of a bundle will be in active builds. Older
+    bundle versions should be removed, since they would presumably never
+    be used by other, active Eclipse projects. If projects or adopters
+    still needed some older version, say for maintenance builds, they
+    can get them from the older R-build repositories where they were
+    last provided. Note: "versions" in this context, refers to
+    differences in the major, minor, or service fields of the version.
+    There is never a case where the same version, but different
+    qualifiers would be in an active build. But, of course, it is common
+    for the qualifier to change from one Orbit release to another, if
+    fixes are made to the manifest, for example.
+
+<!-- -->
+
+-   Why continue to have any bundle in "active builds" once it is built
+    and deemed ready? The reason is to have the ability to have
+    "integration builds" and "milestone builds" in order to get proper
+    feedback and testing before we literally make it permanent in an
+    R-build. There may well be improvements in the build process where
+    only "one or two" bundles are built at a time and then go into the
+    "I-build repository". In that case, the I-build repository would be
+    considered the "active build". Plus, there is a desire to allow
+    consumers, especially of "active builds" to refer to just one
+    repository and "get everything they need" instead of having to refer
+    to several repositories to to piece together their dependencies.
+
+<!-- -->
+
+-   There are a few exceptions to the above "only 1 version" rule:
+
+  
+\- First and foremost, someone requests it, via bugzilla and gives good
+reason why they need an older version still.
+
+\- For any known cases in the yearly Simultaneous Release where
+consumers already use more than one version -- again, for a good reason
+(such as the APIs changed in the newer version, and the project does not
+have the ability or need to move to the new API).
+
+\- There might be cases where the latest version of some package in
+Orbit depends on an older version of a package but that package itself
+can be used independently and someone wants to use a newer version of
+it.
+
+-   Any removal of an older version will normally be done by M3 of the
+    current yearly release cycle (though RC1 is normally considered the
+    "API freeze" date). This allows exceptions or mistakes to be
+    corrected in time for the yearly release with no danger of "last
+    minute" breakage. And M3 is the latest possible time (normally) ...
+    committers should make an effort to do much earlier in a yearly
+    release cycle.
+
+<!-- -->
+
+-   Remember, older versions will stay in our SCM, as they are, forever.
+    That is, the older versions are simply removed from the active
+    builds ... never from SCM nor existing R-build repositories. This is
+    partially so someone could find them if needed to investigate
+    something, but also so we can easily add them back to active builds
+    if needed.
+
+<!-- -->
+
+-   Removals should be documented in bugzilla ... similar to how
+    additions are shoudl be documented in bugzilla.

--- a/README.md
+++ b/README.md
@@ -3,11 +3,13 @@ Eclipse Orbit Recipes
 
 This repositories hosts recipes for building OSGi bundles as part of the Eclipse Orbit project. This repository is based on functionality provided by the [Eclipse EBR maven plug-ins](https://github.com/eclipse/ebr).
 
+The output of the Eclipse Orbit builds are located on download.eclipse.org: <https://download.eclipse.org/tools/orbit/downloads/>
+
 
 The Very Short Version
 ----------------------
 
-See [Adding Bundles To Orbit in 5 Minutes](https://wiki.eclipse.org/Orbit/Adding_Bundles_To_Orbit_In_5_Minutes) as a quick explanation of the contribution process.
+See [Adding Bundles To Orbit in 5 Minutes](Add-bundle-in-5-minutes.md) as a quick explanation of the contribution process.
 
 
 
@@ -19,7 +21,6 @@ any other accessible Maven repository.
 
 1. Install Java 11 (Java 8 and Java 17 don't work) and Maven.
 2. Clone this repository and go into the repository root folder.
-Please ensure you cloned using the [Gerrit URL](https://wiki.eclipse.org/Gerrit#Gerrit_push_URL).
 
 
 
@@ -65,11 +66,11 @@ How to add recipes
 Adding recipes to this repository is part of the general process for adding bundles to Orbit. Please read the
 following additional information first before you proceed.
 
-* [Adding Bundles to Orbit](https://wiki.eclipse.org/Orbit/Adding_Bundles_to_Orbit)
-* [Bundle Checklist](https://wiki.eclipse.org/Orbit_Bundle_Checklist)
-* [Additional articles](https://wiki.eclipse.org/Category:Orbit)
+* [Adding Bundles to Orbit](Add-bundle.md)
+* [Bundle Checklist](Bundle-checklist.md)
+* [Older articles](https://wiki.eclipse.org/Category:Orbit) (these items are from the old Orbit wiki and are retained for reference, but they may contain out of date information)
 
-It's important to ensure that the bundle you're adding has been approved for use. See [IP Provenance](https://wiki.eclipse.org/Orbit/Bundle_Checklist#IP_Provenance) for some instructions. See [IP Prereq Diligence](https://www.eclipse.org/projects/handbook/#ip-prereq-diligence) for further details.
+It's important to ensure that the bundle you're adding has been approved for use. See [IP Provenance](Bundle-checklist.md#ip-provenance) for some instructions. See [IP Prereq Diligence](https://www.eclipse.org/projects/handbook/#ip-prereq-diligence) for further details.
 
 ### 1. Pick a Category
 
@@ -89,34 +90,34 @@ This ensure that proper Orbit defaults are used when creating recipes (for examp
 The preferred method for creating recipes is by consuming a Maven artifact. The EBR Maven plug-in can be used to
 create a recipe including required Eclipse IP information based on data available in Maven artifact poms.
 
-    # create the recipe for a specific Maven artifact
-    # the recipe will be created in a folder named "<symbolicname-of-the-orbit-bundle>_<version>"
-    mvn ebr:create-recipe -DgroupId=<maven-source-groupId> -DartifactId=<maven-source-artifactId> -Dversion=<maven-source-version> -DbundleSymbolicName=<symbolicname-of-the-orbit-bundle>
+```sh
+# create the recipe for a specific Maven artifact
+# the recipe will be created in a folder named "<symbolicname-of-the-orbit-bundle>_<version>"
+mvn ebr:create-recipe -DgroupId=<maven-source-groupId> -DartifactId=<maven-source-artifactId> -Dversion=<maven-source-version> -DbundleSymbolicName=<symbolicname-of-the-orbit-bundle>
 
-    # modify recipe pom and osgi.bnd to suit the needs of the bundle
-    cd <new-recipe-folder>
-    $EDITOR pom.xml
-    $EDITOR osgi.bnd
+# modify recipe pom and osgi.bnd to suit the needs of the bundle
+cd <new-recipe-folder>
+$EDITOR pom.xml
+$EDITOR osgi.bnd
 
-    # do a test build (this will create a default ip_log.xml)
-    # (note the -DirtyWorkingTree=ignore to ignore uncommitted Git changes for now)
-    mvn -U clean package -DdirtyWorkingTree=warning
+# do a test build (this will create a default ip_log.xml)
+# (note the -DirtyWorkingTree=ignore to ignore uncommitted Git changes for now)
+mvn -U clean package -DdirtyWorkingTree=warning
 
-    # review the generated about files
-    ls -la src/main/resources/about_files
-    cat src/main/resources/about.html
+# review the generated about files
+ls -la src/main/resources/about_files
+cat src/main/resources/about.html
 
-    # add new recipe to category pom
-    $EDITOR ../pom.xml
+# add new recipe to category pom
+$EDITOR ../pom.xml
 
-    # update the build feature with your bundle
-    $EDITOR ../../releng/aggregationfeature/feature.xml
+# update the build feature with your bundle
+$EDITOR ../../releng/aggregationfeature/feature.xml
 
-    # add, commit the recipe to Git and push to Gerrit for review
-    git add .; git commit -m "Added org.example.foo 1.2.3"
-    # NOTE: Please ensure you push using the following command so that you don't bypass the code review:
-    git push origin HEAD:refs/for/master
-
+# add, commit the recipe to Git and push to Gerrit for review
+git add .; git commit -m "Added org.example.foo 1.2.3"
+# NOTE: Please push via Pull Request to ensure you don't bypass code review
+```
 
 ### 3. Troubleshooting
 


### PR DESCRIPTION
Part of #1

Along with this change the wiki pages are being updated to point at these md files.