### PR TITLE
Import javax.annotation with more restrictive version range

### DIFF
--- a/javax/javax.annotation_1.3.5/osgi.bnd
+++ b/javax/javax.annotation_1.3.5/osgi.bnd
@@ -1,4 +1,5 @@
 package-version=${version;===;${Bundle-Version}}
+import-version-range=${range;[===,+);${Bundle-Version}}
 
 # Use JRE-provided packages if they exist: classes from the required
 # bundles always take precedence over local classes.
@@ -12,7 +13,7 @@ Export-Package: \
  *;version="${package-version}"
 
 Import-Package: \
- javax.annotation;version="${package-version}", \
- javax.annotation.security;version="${package-version}", \
- javax.annotation.sql;version="${package-version}", \
+ javax.annotation;version="${import-version-range}", \
+ javax.annotation.security;version="${import-version-range}", \
+ javax.annotation.sql;version="${import-version-range}", \
  *;resolution:=optional


### PR DESCRIPTION
Required for proper resolution when jsr305 is present in same target platform.

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/727
https://github.com/eclipse-platform/eclipse.platform.ui/pull/738