### PR TITLE
Apache httpclient 4.5.14: add missing dependencies

### DIFF
--- a/apache/httpcomponents/org.apache.httpcomponents.httpclient_4.5.14/pom.xml
+++ b/apache/httpcomponents/org.apache.httpcomponents.httpclient_4.5.14/pom.xml
@@ -11,11 +11,29 @@
   <version>4.5.14-SNAPSHOT</version>
   <packaging>eclipse-bundle-recipe</packaging>
   <name>Apache HttpClient</name>
+  <properties>
+     <httpclient.version>4.5.14</httpclient.version>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.5.14</version>
+      <version>${httpclient.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient-cache</artifactId>
+      <version>${httpclient.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpmime</artifactId>
+      <version>${httpclient.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>fluent-hc</artifactId>
+      <version>${httpclient.version}</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
8878eeb5 missed to include classes from
- org.apache.httpcomponents:httpclient-cache
- org.apache.httpcomponents:httpmime
- org.apache.httpcomponents:fluent-hc which were included in version 4.5.13 of the httpclient bundle.

This broke some downstream consumers. See
https://community.progress.com/s/article/PDSOE-fails-to-connect-to-OpenEdge-Explorer-after-installing-a-3rd-party-plugin-for-Eclipse

Fixes #20.