### PR TITLE
Remove package import of sun.security.x509

### DIFF
--- a/github/eddsa/net.i2p.crypto.eddsa_0.3.0/osgi.bnd
+++ b/github/eddsa/net.i2p.crypto.eddsa_0.3.0/osgi.bnd
@@ -9,6 +9,7 @@ Export-Package: \
 
 Import-Package: \
  !net.i2p.crypto.eddsa,!net.i2p.crypto.eddsa.*,\
+ !sun.security.x509, \
  *;resolution:=optional
 
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version>=1.6))"


### PR DESCRIPTION
This package is only imported in a test [1] which isn't part of the Orbit bundle we create. The java.base module doesn't export this internal package [2] which can't be used anymore on Java 17 or higher due to the stronger encapsulation of Java internals introduced with JEP 403 [3].

[1] https://github.com/str4d/ed25519-java/blob/7c26a6312c2d2e887210930698706103e0f2da7d/test/net/i2p/crypto/eddsa/EdDSAEngineTest.java#L34
[2] https://github.com/openjdk/jdk17/blob/master/src/java.base/share/classes/module-info.java#L345
[3] https://openjdk.org/jeps/403